### PR TITLE
Use the module configurations used in the main pom.xml - discovered as part of troubleshooting SDK servers hanging

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -3,15 +3,14 @@
 <module configVersion="1.2">
 	
 	<!-- Base Module Properties -->
-	<id>ugandaemrpoc</id>
-	<name>UgandaEMRPOC</name>
-	<version>1.0.0-SNAPSHOT</version>
-	<package>org.openmrs.module.ugandaemrpoc</package>
-	<author>lubwamasamuel</author>
+	<id>${project.parent.artifactId}</id>
+	<name>${project.parent.name}</name>
+	<version>${project.parent.version}</version>
+	<package>${project.parent.groupId}.${project.parent.artifactId}</package>
+	<author>METS Program</author>
 	<description>
-			This module introduces point of care to UgandaEMR
+		${project.parent.description}
 	</description>
-
 	<activator>org.openmrs.module.ugandaemrpoc.UgandaEMRPOCActivator</activator>
 
 	<require_version>${openMRSVersion}</require_version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<legacyuiVersion>1.6.0</legacyuiVersion>
 		<locationbasedaccessVersion>0.1.1</locationbasedaccessVersion>
 		<metadatadeployVersion>1.11.0</metadatadeployVersion>
-		<ugandaemrVersion>3.0.1</ugandaemrVersion>
+		<ugandaemrVersion>3.0.2-SNAPSHOT</ugandaemrVersion>
 		<uiframeworkVersion>3.16.0</uiframeworkVersion>
 		<patientqueueingVersion>1.0.0</patientqueueingVersion>
         <ugandaemrSyncVersion>1.0.1</ugandaemrSyncVersion>


### PR DESCRIPTION
Asana card https://app.asana.com/0/1133167201254915/1171461601457225

This is now similar to aijar https://github.com/METS-Programme/openmrs-module-aijar/blob/b2a2dee029f87068c9f67d8db1c16a63c4874689/omod/src/main/resources/config.xml

Found during this talk discussion https://talk.openmrs.org/t/servers-hung-at-initializing-ehcache-cachemanager/27953/21?u=ssmusoke