### PR TITLE
Add ability to restrict number of patient seen on a day and on public holidays

### DIFF
--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -1069,12 +1069,12 @@
                      async:false,
                      success: function(response){
                          if(response.appointmentcount &gt;= maxNumberOfBooked){
-                            getField('returndate.error').html('The patient cannot be scheduled on ' + formattedDate + ' because the limit of ' + maxNumberOfBooked + ' has already been booked').show();
+                            getField('returndate.error').html('The patient cannot be scheduled on ' + formattedDate + ' because the limit of ' + maxNumberOfBooked + ' has been reached').show();
                              isValid = false;
                          }
                      },
                     error: function(jqXHR, textStatus, errorThrown) {
-                           getField('returndate.error').html('Unable to determine the number of already booked patients on ' + formattedDate + ' due to ' + textStatus ).show();
+                           getField('returndate.error').html('Unable to determine the number of patients scheduled on ' + formattedDate + ' due to ' + textStatus ).show();
                             isValid = false;
                     }
                 });

--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -1068,7 +1068,6 @@
                      url: appointmentCountURL,
                      async:false,
                      success: function(response){
-                         alert(response);
                          if(response.appointmentcount &gt;= maxNumberOfBooked){
                             getField('returndate.error').html('The patient cannot be scheduled on ' + formattedDate + ' because there are already ' + maxNumberOfBooked + ' booked').show();
                              isValid = false;

--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -1069,7 +1069,7 @@
                      async:false,
                      success: function(response){
                          if(response.appointmentcount &gt;= maxNumberOfBooked){
-                            getField('returndate.error').html('The patient cannot be scheduled on ' + formattedDate + ' because there are already ' + maxNumberOfBooked + ' booked').show();
+                            getField('returndate.error').html('The patient cannot be scheduled on ' + formattedDate + ' because the limit of ' + maxNumberOfBooked + ' has already been booked').show();
                              isValid = false;
                          }
                      },
@@ -1087,7 +1087,7 @@
                      async:false,
                      success: function(response){
                          if(response.results.length){
-                            getField('returndate.error').html('Please enter another date because ' + formattedDate + ' is a public holiday, ' + response.results[0].name).show();
+                            getField('returndate.error').html('The patient cannot be scheduled on ' + formattedDate + ' which is a public holiday, ' + response.results[0].name).show();
                              isValid = false;
                          }
                      },

--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -85,8 +85,6 @@
 
             });
 
-
-
             jq(document).ready(function () {
                 $allRows = jq(this).find('.multi-arv-drug');
                 $allRows.hide();
@@ -97,11 +95,7 @@
                 jq('#11-removeEntry').remove();
                 jq('#20-addEntry1').remove();
                 jq('#11-toggleContainer1').show();
-            });
 
-
-
-            jq(document).ready(function () {
                 jq('.addEntry1').on("click", function () {
                     var correctedAddButtonId = parseFloat(this.id) + 1;
                     var contentAddId = "#" + correctedAddButtonId + "-toggleContainer1";
@@ -110,9 +104,7 @@
                     jq('#' + parseFloat(this.id) + '-removeEntry1').toggle(true);
                     return false;
                 });
-            });
 
-            jq(document).ready(function () {
                 jq('.removeEntry1').on("click", function () {
                     var correctedRemoveButtonId = parseFloat(this.id) - 1;
                     var contentAddId = "#" + parseFloat(this.id) + "-toggleContainer1";
@@ -782,7 +774,54 @@
                     jq().toastmessage('showErrorToast', " Patient Not Stable " + instabilityCause + ". \n Only Stable Patients can be enrolled in " + jq("#165143").find("select").find(":selected").text());
                     return false;
                 }
-                return true;
+
+                <!--Not to exceed number of booking for a specific return date. Default is 100 clients-->
+                <!-- formatting date String from YYYY-MM-DD to DD/MM/YYYY to pass in the Url-->
+                var selectedDate = getValue('returndate.value');
+
+                var formattedDate = changeFieldDateToJavascriptDate(selectedDate);
+                var appointmentCountURL = window.location.origin + '/' + OPENMRS_CONTEXT_PATH + '/ws/rest/v1/ugandaemr/appointmentcount?nextAppointmentDate=' + formattedDate.replace(/['"]+/g, '') + '&amp;encounterType=8d5b2be0-c2cc-11de-8d13-0010c6dffd0f';
+
+                isValid = true;
+                var maxNumberOfBooked =  jq("#numberOfPatients").html();
+                jq.ajax({
+                     type: 'GET',
+                     dataType: 'json',
+                     url: appointmentCountURL,
+                     async:false,
+                     success: function(response){
+                         alert(response);
+                         if(response.appointmentcount &gt;= maxNumberOfBooked){
+                            getField('returndate.error').html('The patient cannot be scheduled on ' + formattedDate + ' because there are already ' + maxNumberOfBooked + ' booked').show();
+                             isValid = false;
+                         }
+                     },
+                    error: function(jqXHR, textStatus, errorThrown) {
+                           getField('returndate.error').html('Unable to determine the number of already booked patients on ' + formattedDate + ' due to ' + textStatus ).show();
+                            isValid = false;
+                    }
+                });
+                 <!--Not to book on a public holiday-->
+                var publicHolidayURL = window.location.origin + '/' + OPENMRS_CONTEXT_PATH + '/ws/rest/v1/ugandaemr/publicHoliday?date=' + formattedDate ;
+
+                jq.ajax({
+                     type: 'GET',
+                     url: publicHolidayURL,
+                     async:false,
+                     success: function(response){
+                         if(response.results.length){
+                            getField('returndate.error').html('Please enter another date because ' + formattedDate + ' is a public holiday, ' + response.results[0].name).show();
+                             isValid = false;
+                         }
+                     },
+                    error: function(jqXHR, textStatus, errorThrown) {
+                          getField('returndate.error').html('Unable to determine if ' + formattedDate + ' is a public Holiday').show();
+                            isValid  = false;
+                        }
+                });
+
+                // check the appointment dates
+                return isValid;
             });
         }
 
@@ -975,6 +1014,7 @@
         <lookup
                 complexExpression="#foreach($other_third_line_regimen in $fn.allObs(162989)) $other_first_second_line_regimen.valueText #end"/>
     </span>
+    <span class="hidden" id="numberOfPatients"><lookup expression="fn.globalProperty('ugandaemr.maximumPatientsPerDay')"/></span>
 
     <restrictByRole exclude="HIV Clinic">
         <div>

--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -135,6 +135,7 @@
                 jq('#11-toggleContainer').show();
             });
 
+
             jq(document).ready(function () {
                 jq('.addEntry').on("click", function () {
                     var correctedAddButtonId = parseFloat(this.id) + 1;
@@ -2383,7 +2384,6 @@
                                                 </div>
                                             </div>
                                         </div>
-
                                         <div class="card">
                                             <div class="card-header">DSD Model</div>
                                             <div class="card-body">
@@ -2749,7 +2749,7 @@
                                                                     <label>Hep B Results (if tested)</label>
                                                                 </div>
                                                                 <div class="col-md-8">
-                                                                    <obs id="1322" conceptId="1322" answerConceptIds="703,664"
+                                                                    <obs conceptId="1322" answerConceptIds="703,664"
                                                                          answerLabels="Neg - Negative, Pos - Positive"
                                                                          style="radio"
                                                                          class="hepB-results horizontal"/>
@@ -2915,6 +2915,7 @@
                                                                      answerLabel="{1}" style="checkbox"/>
                                                             </repeat>
                                                         </span>
+
                                                     </div>
                                                 </div>
                                             </div>
@@ -3389,9 +3390,9 @@
                                                 <repeat>
                                                     <template>
                                                         <obsgroup groupingConceptId="160741">
-                                                            <div class="row multi-drug-other" id="{id}-toggleContainer">
+                                                            <div class="row multi-drug" id="{id}-toggleContainer">
                                                                 <div class="col-md-2">
-                                                                    <obs labelText="Drug"   conceptId="1282" answerClasses="Drug" style="autocomplete" class="fullwidth"/>
+                                                                    <obs labelText="Drug" conceptId="1282" answerClasses="Drug" style="autocomplete" class="fullwidth"/>
                                                                 </div>
                                                                 <div class="col-md-2">
                                                                     <obs class="drug-strength" conceptId="1444" labelText="Strength"/>


### PR DESCRIPTION
https://app.asana.com/0/1133167201254915/1185977732524353

To test

1. Set the return visit date to a public holiday in 2020 or 2021 
2. Set the global property ugandaemr.maximumPatientsPerDay to 2, then try to set a patient return visit date to one with more than 2 visits already. Use the concept_id 5096 in the obs table 